### PR TITLE
Unnecessary dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ dependencies {
     compile 'org.antlr:ST4:4.0.8'
     compile 'org.fulib:fulibYaml:1.0.+'
 
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 


### PR DESCRIPTION
JUnit inherits from hamcrest, therefore an import is not necessary.
This small improvement was found by Stefan Lindel.