### PR TITLE
Fix Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,12 @@ dependencies {
 
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.2'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.2'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 buildScan {


### PR DESCRIPTION
When creating #4 I simply forgot to add
```groovy
test {
    useJUnitPlatform()
}
```
as well as a test engine to `build.gradle`.

The pitfall is that this does not lead to failing CI builds, there are simply no tests executed. Should be fixed with this PR.