### PR TITLE
Don't generate toString if there are no suitable attributes

### DIFF
--- a/src/main/java/org/fulib/util/Generator4ClassFile.java
+++ b/src/main/java/org/fulib/util/Generator4ClassFile.java
@@ -278,7 +278,7 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
          .collect(Collectors.toList());
 
       final STGroup group = this.getSTGroup("org/fulib/templates/toString.stg");
-      this.generateFromSignatures(fragmentMap, group, "toStringSignatures", clazz.getModified(),
+      this.generateFromSignatures(fragmentMap, group, "toStringSignatures", nameList.isEmpty() || clazz.getModified(),
                                   st -> st.add("clazz", clazz).add("names", nameList));
    }
 


### PR DESCRIPTION
## Improvements

* `toString` methods are no longer generated when there are no suitable attributes. #39

Closes #39 