### PR TITLE
Don't generate empty removeYou

### DIFF
--- a/src/main/java/org/fulib/util/Generator4ClassFile.java
+++ b/src/main/java/org/fulib/util/Generator4ClassFile.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.fulib.classmodel.FileFragmentMap.*;
 
@@ -285,8 +286,27 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
    private void generateRemoveYou(Clazz clazz, FileFragmentMap fragmentMap)
    {
       final STGroup group = this.getSTGroup("org/fulib/templates/removeYou.stg");
-      final Object[] roles = clazz.getRoles().stream().filter(r -> r.getName() != null).toArray();
-      this.generateFromSignatures(fragmentMap, group, "removeYouSignatures", clazz.getModified(),
-                                  st -> st.add("clazz", clazz).add("roles", roles));
+      final Object[] roles = getRolesForRemoveYou(clazz).toArray();
+      final boolean superCall = needsSuperCallForRemoveYou(clazz);
+      this.generateFromSignatures(fragmentMap, group, "removeYouSignatures", roles.length == 0 || clazz.getModified(),
+                                  st -> st.add("clazz", clazz).add("roles", roles).add("superCall", superCall));
+   }
+
+   private Stream<AssocRole> getRolesForRemoveYou(Clazz clazz)
+   {
+      return clazz.getRoles().stream().filter(r -> r.getName() != null);
+   }
+
+   private boolean needsSuperCallForRemoveYou(Clazz clazz)
+   {
+      Clazz superClazz = clazz;
+      while ((superClazz = superClazz.getSuperClass()) != null)
+      {
+         if (getRolesForRemoveYou(superClazz).findAny().isPresent())
+         {
+            return true;
+         }
+      }
+      return false;
    }
 }

--- a/src/main/resources/org/fulib/templates/removeYou.stg
+++ b/src/main/resources/org/fulib/templates/removeYou.stg
@@ -1,16 +1,16 @@
 import "java.dicts.stg"
 
-removeYouSignatures(clazz, roles) ::= <<
+removeYouSignatures(clazz, roles, superCall) ::= <<
    removeYou: class/<clazz.name>/method/removeYou()
 >>
 
-removeYou(clazz, roles) ::= <<
-   <if(clazz.superClass)>
+removeYou(clazz, roles, superCall) ::= <<
+   <if(superCall)>
    @Override
    <endif>
    public void removeYou()
    {
-      <if(clazz.superClass)>
+      <if(superCall)>
       super.removeYou();
       <endif>
       <roles:removeRole(); separator="\n">

--- a/src/test/java/org/fulib/generator/RemoveYouTest.java
+++ b/src/test/java/org/fulib/generator/RemoveYouTest.java
@@ -1,0 +1,74 @@
+package org.fulib.generator;
+
+import org.fulib.Generator;
+import org.fulib.Tools;
+import org.fulib.builder.ClassModelManager;
+import org.fulib.classmodel.ClassModel;
+import org.fulib.classmodel.Clazz;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RemoveYouTest
+{
+   @Test
+   public void removeYou() throws IOException
+   {
+      final String targetDir = "tmp/removeYou";
+      final String packageName = "org.example.removeYou";
+      final String srcDir = targetDir + "/src";
+      final String outDir = targetDir + "/out";
+
+      Tools.removeDirAndFiles(targetDir);
+
+      // build class model
+
+      final ClassModelManager mm = new ClassModelManager().setMainJavaDir(srcDir).setPackageName(packageName);
+
+      final Clazz empty = mm.haveClass("Empty");
+      final Clazz assocs = mm.haveClass("Assocs", empty, c -> {});
+      mm.associate(assocs, "r1", 1, assocs, "r2", 1);
+      final Clazz empty2 = mm.haveClass("Empty2", assocs, c -> {});
+      final Clazz assocs2 = mm.haveClass("Assocs2", empty2, c -> {});
+      mm.associate(assocs2, "r3", 1, assocs2, "r4", 1);
+
+      // generate
+
+      final ClassModel model = mm.getClassModel();
+      final String packageSrcDir = model.getPackageSrcFolder();
+      new Generator().generate(model);
+
+      // test file contents
+
+      final String emptyContent = readFile(packageSrcDir, "Empty.java");
+      assertThat(emptyContent, not(containsString("void removeYou()")));
+
+      final String assocsContent = readFile(packageSrcDir, "Assocs.java");
+      assertThat(assocsContent, containsString("void removeYou()"));
+      assertThat(assocsContent, not(containsString("super.removeYou()")));
+
+      final String empty2Content = readFile(packageSrcDir, "Empty2.java");
+      assertThat(empty2Content, not(containsString("void removeYou()")));
+
+      final String assocs2Content = readFile(packageSrcDir, "Assocs2.java");
+      assertThat(assocs2Content, containsString("void removeYou()"));
+      assertThat(assocs2Content, containsString("super.removeYou()"));
+      assertThat(assocs2Content, containsString("@Override"));
+
+      // test compile
+
+      int returnCode = Tools.javac(outDir, packageSrcDir);
+      assertThat("compiler return code: ", returnCode, is(0));
+   }
+
+   private static String readFile(String packageSrcDir, String javaFileName) throws IOException
+   {
+      return new String(Files.readAllBytes(Paths.get(packageSrcDir, javaFileName)), StandardCharsets.UTF_8);
+   }
+}


### PR DESCRIPTION
## Bugfixes

* Empty `removeYou` methods are no longer generated. #40 

Closes #40