### PR TITLE
Fixed same method in different classes

### DIFF
--- a/src/main/java/org/fulib/builder/ClassModelManager.java
+++ b/src/main/java/org/fulib/builder/ClassModelManager.java
@@ -716,7 +716,7 @@ public class ClassModelManager implements IModelManager
 
    public FMethod haveMethod(Clazz owner, String declaration, String body)
    {
-      FMethod method = this.getMethod(declaration);
+      FMethod method = this.getMethod(owner, declaration);
 
       if (method == null)
       {


### PR DESCRIPTION
## Bugfixes

* Fixed an issue in `ClassModelManager.haveMethod` that would disallow two methods with the same declaration in different classes.