### PR TITLE
Treat void and boolean as primitive types

### DIFF
--- a/src/main/resources/org/fulib/templates/java.dicts.stg
+++ b/src/main/resources/org/fulib/templates/java.dicts.stg
@@ -1,4 +1,6 @@
 primitive ::= [
+   "void": true,
+   "boolean": true,
    "byte": true,
    "short": true,
    "char": true,
@@ -10,6 +12,8 @@ primitive ::= [
 ]
 
 boxMap ::= [
+   "void": "Void",
+   "boolean": "Boolean",
    "byte": "Byte",
    "short": "Short",
    "char": "Character",


### PR DESCRIPTION
The types `void` and `boolean` are now properly treated as primitives.
Previously, this was problematic because `boolean` was not properly boxed where needed,
and was also compared using `Objects.equals`, whereas `==` would have been sufficient.
`void` is actually not very useful as an attribute type, but was added for consistency.

## Bugfixes

* The code generator now treats the types `void` and `boolean` as primitives.