### PR TITLE
Support C-style Arrays for Parameters

### DIFF
--- a/src/main/antlr/FulibClass.g4
+++ b/src/main/antlr/FulibClass.g4
@@ -51,7 +51,7 @@ methodMember: (typeParamList annotatedType | type) IDENTIFIER
         (balancedBraces | SEMI);
 
 parameterList: LPAREN (parameter (COMMA parameter)*)? RPAREN;
-parameter: (modifier | annotation)* type ELLIPSIS? (IDENTIFIER | (IDENTIFIER DOT)? THIS);
+parameter: (modifier | annotation)* type ELLIPSIS? (IDENTIFIER arraySuffix* | (IDENTIFIER DOT)? THIS);
 
 // --------------- Types ---------------
 

--- a/src/main/java/org/fulib/classmodel/FMethod.java
+++ b/src/main/java/org/fulib/classmodel/FMethod.java
@@ -182,6 +182,12 @@ public class FMethod
       {
          final String name = paramCtx.IDENTIFIER().getText();
          String type = inputText(paramCtx.type());
+         for (int arrayDimensions = paramCtx.arraySuffix().size(); arrayDimensions > 0; arrayDimensions--)
+         {
+            // C-style arrays are so rare that normal methods don't need to pay the StringBuilder overhead
+            // noinspection StringConcatenationInLoop
+            type += "[]";
+         }
          if (paramCtx.ELLIPSIS() != null)
          {
             type += "...";

--- a/src/main/java/org/fulib/classmodel/FMethod.java
+++ b/src/main/java/org/fulib/classmodel/FMethod.java
@@ -153,9 +153,10 @@ public class FMethod
 
       String returnType = inputText(memberCtx.type());
 
-      for (Object ignored : memberCtx.arraySuffix())
+      for (int arrayDimensions = memberCtx.arraySuffix().size(); arrayDimensions > 0; arrayDimensions--)
       {
-         //noinspection StringConcatenationInLoop
+         // C-style arrays are so rare that normal methods don't need to pay the StringBuilder overhead
+         // noinspection StringConcatenationInLoop
          returnType += "[]";
       }
 

--- a/src/main/java/org/fulib/parser/FragmentMapBuilder.java
+++ b/src/main/java/org/fulib/parser/FragmentMapBuilder.java
@@ -267,6 +267,10 @@ public class FragmentMapBuilder extends FulibClassBaseListener
          return;
       }
       writeType(paramCtx.type(), builder);
+      for (int arrayDimensions = paramCtx.arraySuffix().size(); arrayDimensions > 0; arrayDimensions--)
+      {
+         builder.append("[]");
+      }
       if (paramCtx.ELLIPSIS() != null)
       {
          builder.append("...");

--- a/src/test/java/org/fulib/classmodel/FMethodTest.java
+++ b/src/test/java/org/fulib/classmodel/FMethodTest.java
@@ -56,4 +56,26 @@ class FMethodTest
       assertThat(parametricTypes.getParams(), hasEntry("ints", "List<Integer>"));
       assertThat(parametricTypes.getParams(), hasEntry("matrix", "Map<Integer, Map<Integer, String>>"));
    }
+
+   @Test
+   void setDeclaration_cStyleArrays()
+   {
+      final FMethod cStyleArrays = new FMethod();
+      cStyleArrays.setDeclaration("String cStyleArrays(String args[])[]");
+      assertThat(cStyleArrays.getReturnType(), equalTo("String[]"));
+      assertThat(cStyleArrays.getParams(), aMapWithSize(1));
+      assertThat(cStyleArrays.getParams(), hasEntry("args", "String[]"));
+
+      final FMethod cStyleMultiArrays = new FMethod();
+      cStyleMultiArrays.setDeclaration("String cStyleMultiArrays(String args[][])[][]");
+      assertThat(cStyleMultiArrays.getReturnType(), equalTo("String[][]"));
+      assertThat(cStyleMultiArrays.getParams(), aMapWithSize(1));
+      assertThat(cStyleMultiArrays.getParams(), hasEntry("args", "String[][]"));
+
+      final FMethod cStyleMixedArrays = new FMethod();
+      cStyleMixedArrays.setDeclaration("String[] cStyleMixedArrays(String[] args[])[]");
+      assertThat(cStyleMixedArrays.getReturnType(), equalTo("String[][]"));
+      assertThat(cStyleMixedArrays.getParams(), aMapWithSize(1));
+      assertThat(cStyleMixedArrays.getParams(), hasEntry("args", "String[][]"));
+   }
 }


### PR DESCRIPTION
## Bugfixes

* The Java parser now supports C-style arrays for parameters.
* The `FMethod.setDeclaration` method now supports C-style arrays for parameters.
