### PR TITLE
Fix duplicate members

### DIFF
--- a/src/main/java/org/fulib/classmodel/FileFragmentMap.java
+++ b/src/main/java/org/fulib/classmodel/FileFragmentMap.java
@@ -139,9 +139,31 @@ public class FileFragmentMap
     */
    public CodeFragment getFragment(String key)
    {
-      final String[] path = getPath(key);
-      final Fragment ancestor = this.root.getAncestor(path);
-      return ancestor instanceof CodeFragment ? (CodeFragment) ancestor : null;
+      return findFragment(this.root, getParentKeys(key), 0, key);
+   }
+
+   private static CodeFragment findFragment(CompoundFragment parent, String[] parentKeys, int index, String key)
+   {
+      if (index == parentKeys.length)
+      {
+         final Fragment child = parent.getChildWithKey(key);
+         return child instanceof CodeFragment ? (CodeFragment) child : null;
+      }
+
+      for (final Fragment child : parent.getChildren())
+      {
+         if (!(child instanceof CompoundFragment) || !child.getKey().equals(parentKeys[index]))
+         {
+            continue;
+         }
+
+         final CodeFragment fragment = findFragment((CompoundFragment) child, parentKeys, index + 1, key);
+         if (fragment != null)
+         {
+            return fragment;
+         }
+      }
+      return null;
    }
 
    static String[] getPath(String key)

--- a/src/test/java/org/fulib/classmodel/FileFragmentMapTest.java
+++ b/src/test/java/org/fulib/classmodel/FileFragmentMapTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,7 +19,8 @@ class FileFragmentMapTest
    void mergeClassDecl()
    {
       assertEquals("@Cool class Foo\n{", FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo {"));
-      assertEquals("@Cool class Foo extends Bar\n{", FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo extends Bar {"));
+      assertEquals("@Cool class Foo extends Bar\n{",
+                   FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo extends Bar {"));
       assertEquals("class Foo implements Serializable {",
                    FileFragmentMap.mergeClassDecl("class Foo implements Serializable {", "class Foo {"));
       assertEquals("class Foo extends Bar implements Baz {",
@@ -40,6 +44,59 @@ class FileFragmentMapTest
       assertThat(FileFragmentMap.getParentKeys("org/foo"), arrayContaining("org"));
       assertThat(FileFragmentMap.getParentKeys("org/foo/bar"), arrayContaining("org", "org/foo"));
       assertThat(FileFragmentMap.getParentKeys("org/foo/bar/baz"), arrayContaining("org", "org/foo", "org/foo/bar"));
+   }
+
+   @Test
+   void getFragment()
+   {
+      // language=JAVA
+      final String example =
+         "package org.example;\n" + "\n" + "import java.util.List;\n" + "import java.util.Map;\n" + "\n"
+         + "class Example {\n" + "   int i;\n" + "   void foo() {}\n" + "   int j;\n" + "   void bar() {}\n"
+         + "   void baz(String s) {}\n" + "   void baz(int i) {}\n" + "}\n";
+      final FileFragmentMap map = FragmentMapBuilder.parse("Example.java", CharStreams.fromString(example));
+
+      final String[] keys = {
+         "package",
+         "import/java.util.List",
+         "import/java.util.Map",
+         "class/Example/classDecl",
+         "class/Example/attribute/i",
+         "class/Example/method/foo()",
+         "class/Example/attribute/j",
+         "class/Example/method/bar()",
+         "class/Example/method/baz(String)",
+         "class/Example/method/baz(int)",
+         "class/Example/classEnd",
+         "eof",
+      };
+      final String[] texts = {
+         "package org.example;",
+         "import java.util.List;",
+         "import java.util.Map;",
+         "class Example {",
+         "int i;",
+         "void foo() {}",
+         "int j;",
+         "void bar() {}",
+         "void baz(String s) {}",
+         "void baz(int i) {}",
+         "}",
+         "",
+      };
+
+      for (int i = 0; i < keys.length; i++)
+      {
+         final CodeFragment fragment = map.getFragment(keys[i]);
+         assertThat("fragment with key '" + keys[i] + "' exists", fragment, notNullValue());
+         assertThat("fragment with key '" + keys[i] + "' has correct text", fragment.getText(), equalTo(texts[i]));
+      }
+
+      assertThat(map
+                    .codeFragments()
+                    .map(CodeFragment::getKey)
+                    .filter(s -> !s.endsWith("#gap-before") && !s.endsWith("#start"))
+                    .collect(Collectors.toList()), equalTo(Arrays.asList(keys)));
    }
 
    @ParameterizedTest()

--- a/src/test/resources/templates/university.stg
+++ b/src/test/resources/templates/university.stg
@@ -1,5 +1,3 @@
-
-
 university(packageName) ::= <<
 
 // MIT license
@@ -19,6 +17,9 @@ public class University
     {
         return 42;
     }
+
+    // attribute between methods
+    private static final long serialVersionUID = 12345L;
 
    @Override // no fulib
    public String toString()


### PR DESCRIPTION
See #45 for a discussion on when this was possible.
In short - when mixing methods and attributes instead of grouping them all together.

## Bugfixes

* Fixed an issue where mixing attributes with methods would lead to the generation of duplicate members.