### PR TITLE
Sanitize attribute and method signatures

### DIFF
--- a/src/main/java/org/fulib/classmodel/FMethod.java
+++ b/src/main/java/org/fulib/classmodel/FMethod.java
@@ -2,6 +2,7 @@ package org.fulib.classmodel;
 
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.Interval;
+import org.fulib.parser.FragmentMapBuilder;
 import org.fulib.parser.FulibClassLexer;
 import org.fulib.parser.FulibClassParser;
 
@@ -282,10 +283,14 @@ public class FMethod
     */
    public String getSignature()
    {
-      String paramTypes = this.getParams().entrySet().stream().filter(e -> !"this".equals(e.getKey()))
-                              .map(Map.Entry::getValue).collect(Collectors.joining(","));
+      final CharStream input = CharStreams.fromString("(" + this.getParamsString() + ")");
+      final FulibClassLexer lexer = new FulibClassLexer(input);
+      final FulibClassParser parser = new FulibClassParser(new CommonTokenStream(lexer));
+      final FulibClassParser.ParameterListContext paramsCtx = parser.parameterList();
+      final String paramsSignature = FragmentMapBuilder.getParamsSignature(paramsCtx);
+
       return FileFragmentMap.CLASS + '/' + this.getClazz().getName() + '/' + FileFragmentMap.METHOD + '/'
-             + this.getName() + '(' + paramTypes + ')';
+             + this.getName() + paramsSignature;
    }
 
    /**

--- a/src/main/java/org/fulib/classmodel/classModel.yaml
+++ b/src/main/java/org/fulib/classmodel/classModel.yaml
@@ -93,6 +93,7 @@
   name: 	packageName
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - classModel_mainJavaDir: 	Attribute
   clazz: 	classModel
@@ -101,6 +102,7 @@
   name: 	mainJavaDir
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - classModel_defaultCollectionType: 	Attribute
   clazz: 	classModel
@@ -109,6 +111,7 @@
   name: 	defaultCollectionType
   propertyStyle: 	Bean
   type: 	CollectionType
+  typeSignature: 	CollectionType
 
 - classModel_defaultPropertyStyle: 	Attribute
   clazz: 	classModel
@@ -118,6 +121,7 @@
   name: 	defaultPropertyStyle
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - classModel_classes: 	AssocRole
   aggregation: 	false
@@ -138,6 +142,7 @@
   name: 	name
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - clazz_propertyStyle: 	Attribute
   clazz: 	clazz
@@ -146,6 +151,7 @@
   name: 	propertyStyle
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - clazz_modified: 	Attribute
   clazz: 	clazz
@@ -154,6 +160,7 @@
   name: 	modified
   propertyStyle: 	Bean
   type: 	boolean
+  typeSignature: 	boolean
 
 - clazz_imports: 	Attribute
   clazz: 	clazz
@@ -163,6 +170,7 @@
   name: 	imports
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - clazz_model: 	AssocRole
   aggregation: 	false
@@ -243,6 +251,7 @@
   name: 	name
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - attribute_type: 	Attribute
   clazz: 	attribute
@@ -251,6 +260,7 @@
   name: 	type
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - attribute_collectionType: 	Attribute
   clazz: 	attribute
@@ -259,6 +269,7 @@
   name: 	collectionType
   propertyStyle: 	Bean
   type: 	CollectionType
+  typeSignature: 	CollectionType
 
 - attribute_initialization: 	Attribute
   clazz: 	attribute
@@ -267,6 +278,7 @@
   name: 	initialization
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - attribute_propertyStyle: 	Attribute
   clazz: 	attribute
@@ -275,6 +287,7 @@
   name: 	propertyStyle
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - attribute_modified: 	Attribute
   clazz: 	attribute
@@ -283,6 +296,7 @@
   name: 	modified
   propertyStyle: 	Bean
   type: 	boolean
+  typeSignature: 	boolean
 
 - attribute_clazz: 	AssocRole
   aggregation: 	false
@@ -303,6 +317,7 @@
   name: 	name
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - assocRole_cardinality: 	Attribute
   clazz: 	assocRole
@@ -311,6 +326,7 @@
   name: 	cardinality
   propertyStyle: 	Bean
   type: 	int
+  typeSignature: 	int
 
 - assocRole_collectionType: 	Attribute
   clazz: 	assocRole
@@ -319,6 +335,7 @@
   name: 	collectionType
   propertyStyle: 	Bean
   type: 	CollectionType
+  typeSignature: 	CollectionType
 
 - assocRole_aggregation: 	Attribute
   clazz: 	assocRole
@@ -327,6 +344,7 @@
   name: 	aggregation
   propertyStyle: 	Bean
   type: 	boolean
+  typeSignature: 	boolean
 
 - assocRole_propertyStyle: 	Attribute
   clazz: 	assocRole
@@ -335,6 +353,7 @@
   name: 	propertyStyle
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - assocRole_modified: 	Attribute
   clazz: 	assocRole
@@ -343,6 +362,7 @@
   name: 	modified
   propertyStyle: 	Bean
   type: 	boolean
+  typeSignature: 	boolean
 
 - assocRole_clazz: 	AssocRole
   aggregation: 	false
@@ -375,6 +395,7 @@
   name: 	methodBody
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - fMethod_modified: 	Attribute
   clazz: 	fMethod
@@ -383,6 +404,7 @@
   name: 	modified
   propertyStyle: 	Bean
   type: 	boolean
+  typeSignature: 	boolean
 
 - fMethod_modifiers: 	Attribute
   clazz: 	fMethod
@@ -392,6 +414,7 @@
   name: 	modifiers
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - fMethod_annotations: 	Attribute
   clazz: 	fMethod
@@ -400,6 +423,7 @@
   name: 	annotations
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - fMethod_clazz: 	AssocRole
   aggregation: 	false
@@ -420,6 +444,7 @@
   name: 	fileName
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - fragment_key: 	Attribute
   clazz: 	fragment
@@ -428,6 +453,7 @@
   name: 	key
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - fragment_parent: 	AssocRole
   aggregation: 	false
@@ -448,6 +474,7 @@
   name: 	text
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - compoundFragment_children: 	AssocRole
   aggregation: 	false

--- a/src/main/java/org/fulib/parser/FragmentMapBuilder.java
+++ b/src/main/java/org/fulib/parser/FragmentMapBuilder.java
@@ -277,6 +277,13 @@ public class FragmentMapBuilder extends FulibClassBaseListener
       }
    }
 
+   public static String getTypeSignature(TypeContext typeCtx)
+   {
+      final StringBuilder builder = new StringBuilder();
+      writeType(typeCtx, builder);
+      return builder.toString();
+   }
+
    private static void writeType(TypeContext typeCtx, StringBuilder builder)
    {
       if (typeCtx.primitiveType() != null)

--- a/src/main/java/org/fulib/parser/FragmentMapBuilder.java
+++ b/src/main/java/org/fulib/parser/FragmentMapBuilder.java
@@ -239,6 +239,13 @@ public class FragmentMapBuilder extends FulibClassBaseListener
       this.addCodeFragment(signature.toString(), memberCtx);
    }
 
+   public static String getParamsSignature(ParameterListContext paramsCtx)
+   {
+      final StringBuilder builder = new StringBuilder();
+      writeParams(builder, paramsCtx);
+      return builder.toString();
+   }
+
    private static void writeParams(StringBuilder signature, ParameterListContext paramsCtx)
    {
       signature.append('(');

--- a/src/main/resources/org/fulib/templates/attributes.bean.stg
+++ b/src/main/resources/org/fulib/templates/attributes.bean.stg
@@ -20,7 +20,7 @@ attrSet(attr) ::= <<
 // --------------- With ---------------
 
 attrWithItem(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr)> value)
+   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr.type)> value)
    {
       if (this.<attr.name> == null)
       {
@@ -35,7 +35,7 @@ attrWithItem(attr) ::= <<
 >>
 
 attrWithArray(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr)>... value)
+   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr.type)>... value)
    {
       for (final <attr.type> item : value)
       {
@@ -46,9 +46,9 @@ attrWithArray(attr) ::= <<
 >>
 
 attrWithColl(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr)>\> value)
+   public <attr.clazz.name> with<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr.type)>\> value)
    {
-      for (final <box(attr)> item : value)
+      for (final <box(attr.type)> item : value)
       {
          this.with<attr.name; format="cap">(item);
       }
@@ -59,7 +59,7 @@ attrWithColl(attr) ::= <<
 // --------------- Without ---------------
 
 attrWithoutItem(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr)> value)
+   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr.type)> value)
    {
       if (this.<attr.name> != null && this.<attr.name>.removeAll(import(java.util.Collections).singleton(value)))
       {
@@ -70,9 +70,9 @@ attrWithoutItem(attr) ::= <<
 >>
 
 attrWithoutArray(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr)>... value)
+   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr.type)>... value)
    {
-      for (final <box(attr)> item : value)
+      for (final <box(attr.type)> item : value)
       {
          this.without<attr.name; format="cap">(item);
       }
@@ -81,9 +81,9 @@ attrWithoutArray(attr) ::= <<
 >>
 
 attrWithoutColl(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr)>\> value)
+   public <attr.clazz.name> without<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr.type)>\> value)
    {
-      for (final <box(attr)> item : value)
+      for (final <box(attr.type)> item : value)
       {
          this.without<attr.name; format="cap">(item);
       }
@@ -94,19 +94,19 @@ attrWithoutColl(attr) ::= <<
 // --------------- Set All ---------------
 
 attrSetAllArray(attr) ::= <<
-   public <attr.clazz.name> set<attr.name; format="cap">(<box(attr)>... value)
+   public <attr.clazz.name> set<attr.name; format="cap">(<box(attr.type)>... value)
    {
       return this.set<attr.name; format="cap">(import(java.util.Arrays).asList(value));
    }
 >>
 
 attrSetAllColl(attr) ::= <<
-   public <attr.clazz.name> set<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr)>\> value)
+   public <attr.clazz.name> set<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr.type)>\> value)
    {
       if (this.<attr.name> == null)
       {
          this.<attr.name> = new <collectionImpl(attr)>(value);
-         for (final <box(attr)> newItem : value)
+         for (final <box(attr.type)> newItem : value)
          {
             this.firePropertyChange(PROPERTY_<attr.name>, null, newItem);
          }
@@ -118,7 +118,7 @@ attrSetAllColl(attr) ::= <<
          return this;
       }
 
-      for (final <box(attr)> oldItem : this.<attr.name>)
+      for (final <box(attr.type)> oldItem : this.<attr.name>)
       {
          if (!value.contains(oldItem))
          {
@@ -126,7 +126,7 @@ attrSetAllColl(attr) ::= <<
          }
       }
 
-      for (final <box(attr)> newItem : value)
+      for (final <box(attr.type)> newItem : value)
       {
          if (!this.<attr.name>.contains(newItem))
          {

--- a/src/main/resources/org/fulib/templates/attributes.javafx.stg
+++ b/src/main/resources/org/fulib/templates/attributes.javafx.stg
@@ -2,9 +2,9 @@ import "attributes.bean.stg"
 
 propertyType(attr, prefix="") ::= <%
 <if(attr.collection)>
-   import(javafx.beans.property.<prefix>ListProperty)\<<box(attr)>>
+   import(javafx.beans.property.<prefix>ListProperty)\<<box(attr.type)>>
 <elseif(primitive.(attr.type))>
-   import(javafx.beans.property.<prefix><box(attr)>Property)
+   import(javafx.beans.property.<prefix><box(attr.type)>Property)
 <else>
    import(javafx.beans.property.<prefix>ObjectProperty)\<<attr.type>>
 <endif>
@@ -25,7 +25,7 @@ initMethod(attr) ::= <<
 
 attrGet(attr) ::= <<
 <if(attr.collection)>
-   public java.util.List\<<box(attr)>\> get<attr.name; format="cap">()
+   public java.util.List\<<box(attr.type)>\> get<attr.name; format="cap">()
 <else>
    public <attr.type> get<attr.name; format="cap">()
 <endif>
@@ -53,7 +53,7 @@ propertyGet(attr) ::= <<
 >>
 
 attrWithItem(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr)> value)
+   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr.type)> value)
    {
       this.<attr.name>.add(value);
       return this;
@@ -61,7 +61,7 @@ attrWithItem(attr) ::= <<
 >>
 
 attrWithoutItem(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr)> value)
+   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr.type)> value)
    {
       this.<attr.name>.removeAll(value);
       return this;

--- a/src/main/resources/org/fulib/templates/attributes.pojo.stg
+++ b/src/main/resources/org/fulib/templates/attributes.pojo.stg
@@ -28,14 +28,14 @@ attrSignatures(attr) ::= <<
    propertyGet:      class/<attr.clazz.name>/method/<attr.name>Property()
    <endif>
    <if(attr.collection)>
-   attrWithItem:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr.type)>)
-   attrWithArray:    class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr.type)>...)
-   attrWithColl:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(Collection\<? extends <box(attr.type)>\>)
-   attrWithoutItem:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr.type)>)
-   attrWithoutArray: class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr.type)>...)
-   attrWithoutColl:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(Collection\<? extends <box(attr.type)>\>)
+   attrWithItem:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr.typeSignature)>)
+   attrWithArray:    class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr.typeSignature)>...)
+   attrWithColl:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(Collection\<? extends <box(attr.typeSignature)>\>)
+   attrWithoutItem:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr.typeSignature)>)
+   attrWithoutArray: class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr.typeSignature)>...)
+   attrWithoutColl:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(Collection\<? extends <box(attr.typeSignature)>\>)
    <else>
-   attrSet:          class/<attr.clazz.name>/method/set<attr.name; format="cap">(<attr.type>)
+   attrSet:          class/<attr.clazz.name>/method/set<attr.name; format="cap">(<attr.typeSignature>)
    <endif>
 >>
 

--- a/src/main/resources/org/fulib/templates/attributes.pojo.stg
+++ b/src/main/resources/org/fulib/templates/attributes.pojo.stg
@@ -5,12 +5,8 @@ collectionImpl(attr) ::= <%
 <if(attr.collectionType.generic)>\<><endif>
 %>
 
-box(attr) ::= <%
-<boxMap.(attr.type)>
-%>
-
 collectionItf(attr) ::= <%
-<attr.collectionType.itf.simpleName>\<<box(attr)>>
+<attr.collectionType.itf.simpleName>\<<box(attr.type)>>
 %>
 
 attrType(attr) ::= <%
@@ -32,12 +28,12 @@ attrSignatures(attr) ::= <<
    propertyGet:      class/<attr.clazz.name>/method/<attr.name>Property()
    <endif>
    <if(attr.collection)>
-   attrWithItem:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr)>)
-   attrWithArray:    class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr)>...)
-   attrWithColl:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(Collection\<? extends <box(attr)>\>)
-   attrWithoutItem:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr)>)
-   attrWithoutArray: class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr)>...)
-   attrWithoutColl:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(Collection\<? extends <box(attr)>\>)
+   attrWithItem:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr.type)>)
+   attrWithArray:    class/<attr.clazz.name>/method/with<attr.name; format="cap">(<box(attr.type)>...)
+   attrWithColl:     class/<attr.clazz.name>/method/with<attr.name; format="cap">(Collection\<? extends <box(attr.type)>\>)
+   attrWithoutItem:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr.type)>)
+   attrWithoutArray: class/<attr.clazz.name>/method/without<attr.name; format="cap">(<box(attr.type)>...)
+   attrWithoutColl:  class/<attr.clazz.name>/method/without<attr.name; format="cap">(Collection\<? extends <box(attr.type)>\>)
    <else>
    attrSet:          class/<attr.clazz.name>/method/set<attr.name; format="cap">(<attr.type>)
    <endif>
@@ -75,7 +71,7 @@ attrSet(attr) ::= <<
 // --------------- With ---------------
 
 attrWithItem(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr)> value)
+   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr.type)> value)
    {
       if (this.<attr.name> == null)
       {
@@ -87,7 +83,7 @@ attrWithItem(attr) ::= <<
 >>
 
 attrWithArray(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr)>... value)
+   public <attr.clazz.name> with<attr.name; format="cap">(<box(attr.type)>... value)
    {
       this.with<attr.name; format="cap">(import(java.util.Arrays).asList(value));
       return this;
@@ -95,7 +91,7 @@ attrWithArray(attr) ::= <<
 >>
 
 attrWithColl(attr) ::= <<
-   public <attr.clazz.name> with<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr)>\> value)
+   public <attr.clazz.name> with<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr.type)>\> value)
    {
       if (this.<attr.name> == null)
       {
@@ -112,7 +108,7 @@ attrWithColl(attr) ::= <<
 // --------------- Without ---------------
 
 attrWithoutItem(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr)> value)
+   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr.type)> value)
    {
       this.<attr.name>.removeAll(import(java.util.Collections).singleton(value));
       return this;
@@ -120,7 +116,7 @@ attrWithoutItem(attr) ::= <<
 >>
 
 attrWithoutArray(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr)>... value)
+   public <attr.clazz.name> without<attr.name; format="cap">(<box(attr.type)>... value)
    {
       this.without<attr.name; format="cap">(import(java.util.Arrays).asList(value));
       return this;
@@ -128,7 +124,7 @@ attrWithoutArray(attr) ::= <<
 >>
 
 attrWithoutColl(attr) ::= <<
-   public <attr.clazz.name> without<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr)>\> value)
+   public <attr.clazz.name> without<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr.type)>\> value)
    {
       if (this.<attr.name> != null)
       {
@@ -141,14 +137,14 @@ attrWithoutColl(attr) ::= <<
 // --------------- Set All ---------------
 
 attrSetAllArray(attr) ::= <<
-   public <attr.clazz.name> set<attr.name; format="cap">(<box(attr)>... value)
+   public <attr.clazz.name> set<attr.name; format="cap">(<box(attr.type)>... value)
    {
       return this.set<attr.name; format="cap">(import(java.util.Arrays).asList(value));
    }
 >>
 
 attrSetAllColl(attr) ::= <<
-   public <attr.clazz.name> set<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr)>\> value)
+   public <attr.clazz.name> set<attr.name; format="cap">(import(java.util.Collection)\<? extends <box(attr.type)>\> value)
    {
       if (this.<attr.name> == null)
       {

--- a/src/main/resources/org/fulib/templates/java.dicts.stg
+++ b/src/main/resources/org/fulib/templates/java.dicts.stg
@@ -24,6 +24,8 @@ boxMap ::= [
    default: key
 ]
 
+box(type) ::= "<boxMap.(type)>"
+
 javaFX ::= [
    "JavaFX": true,
    default: false

--- a/src/test/java/org/fulib/classmodel/AttributeTest.java
+++ b/src/test/java/org/fulib/classmodel/AttributeTest.java
@@ -1,0 +1,34 @@
+package org.fulib.classmodel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AttributeTest
+{
+   @Test
+   @SuppressWarnings("deprecation") // the getTypeSignature method is only deprecated for external uses
+   void setType()
+   {
+      final Attribute primitive = new Attribute();
+      primitive.setType("int");
+      assertThat(primitive.getTypeSignature(), equalTo("int"));
+
+      final Attribute simple = new Attribute();
+      simple.setType("String");
+      assertThat(simple.getTypeSignature(), equalTo("String"));
+
+      final Attribute generic = new Attribute();
+      generic.setType("List<String>");
+      assertThat(generic.getTypeSignature(), equalTo("List<String>"));
+
+      final Attribute generic2 = new Attribute();
+      generic2.setType("Map<String, Integer>");
+      assertThat(generic2.getTypeSignature(), equalTo("Map<String,Integer>"));
+
+      final Attribute annotated = new Attribute();
+      annotated.setType("Map<String, @NonNull Object>");
+      assertThat(annotated.getTypeSignature(), equalTo("Map<String,Object>"));
+   }
+}

--- a/src/test/java/org/fulib/classmodel/FMethodTest.java
+++ b/src/test/java/org/fulib/classmodel/FMethodTest.java
@@ -11,15 +11,18 @@ class FMethodTest
    @Test
    void setDeclaration()
    {
-      final FMethod simple = new FMethod();
+      final Clazz clazz = new Clazz().setName("Foo");
+
+      final FMethod simple = new FMethod().setClazz(clazz);
       simple.setDeclaration("void foo()");
       assertThat(simple.getModifiers(), equalTo(""));
       assertThat(simple.getReturnType(), equalTo("void"));
       assertThat(simple.getAnnotations(), emptyString());
       assertThat(simple.getName(), equalTo("foo"));
       assertThat(simple.getParams(), anEmptyMap());
+      assertThat(simple.getSignature(), equalTo("class/Foo/method/foo()"));
 
-      final FMethod oneParam = new FMethod();
+      final FMethod oneParam = new FMethod().setClazz(clazz);
       oneParam.setDeclaration("@NonNull private String bar(String par1)");
       assertThat(oneParam.getModifiers(), equalTo("private"));
       assertThat(oneParam.getReturnType(), equalTo("String"));
@@ -27,8 +30,9 @@ class FMethodTest
       assertThat(oneParam.getName(), equalTo("bar"));
       assertThat(oneParam.getParams(), aMapWithSize(1));
       assertThat(oneParam.getParams(), hasEntry("par1", "String"));
+      assertThat(oneParam.getSignature(), equalTo("class/Foo/method/bar(String)"));
 
-      final FMethod twoParams = new FMethod();
+      final FMethod twoParams = new FMethod().setClazz(clazz);
       twoParams.setDeclaration("@Override @NonNull protected synchronized String baz(String par1, int par2)");
       assertThat(twoParams.getModifiers(), equalTo("protected synchronized"));
       assertThat(twoParams.getReturnType(), equalTo("String"));
@@ -37,16 +41,18 @@ class FMethodTest
       assertThat(twoParams.getParams(), aMapWithSize(2));
       assertThat(twoParams.getParams(), hasEntry("par1", "String"));
       assertThat(twoParams.getParams(), hasEntry("par2", "int"));
+      assertThat(twoParams.getSignature(), equalTo("class/Foo/method/baz(String,int)"));
 
-      final FMethod varargs = new FMethod();
+      final FMethod varargs = new FMethod().setClazz(clazz);
       varargs.setDeclaration("public void varargs(String... args)");
       assertThat(varargs.getModifiers(), equalTo("public"));
       assertThat(varargs.getReturnType(), equalTo("void"));
       assertThat(varargs.getName(), equalTo("varargs"));
       assertThat(varargs.getParams(), aMapWithSize(1));
       assertThat(varargs.getParams(), hasEntry("args", "String..."));
+      assertThat(varargs.getSignature(), equalTo("class/Foo/method/varargs(String...)"));
 
-      final FMethod parametricTypes = new FMethod();
+      final FMethod parametricTypes = new FMethod().setClazz(clazz);
       parametricTypes.setDeclaration(
          "public Map<String, Integer> parametricTypes(List<Integer> ints, Map<Integer, Map<Integer, String>> matrix)");
       assertThat(parametricTypes.getModifiers(), equalTo("public"));
@@ -55,27 +61,34 @@ class FMethodTest
       assertThat(parametricTypes.getParams(), aMapWithSize(2));
       assertThat(parametricTypes.getParams(), hasEntry("ints", "List<Integer>"));
       assertThat(parametricTypes.getParams(), hasEntry("matrix", "Map<Integer, Map<Integer, String>>"));
+      assertThat(parametricTypes.getSignature(),
+                 equalTo("class/Foo/method/parametricTypes(List<Integer>,Map<Integer,Map<Integer,String>>)"));
    }
 
    @Test
    void setDeclaration_cStyleArrays()
    {
-      final FMethod cStyleArrays = new FMethod();
+      final Clazz clazz = new Clazz().setName("Foo");
+
+      final FMethod cStyleArrays = new FMethod().setClazz(clazz);
       cStyleArrays.setDeclaration("String cStyleArrays(String args[])[]");
       assertThat(cStyleArrays.getReturnType(), equalTo("String[]"));
       assertThat(cStyleArrays.getParams(), aMapWithSize(1));
       assertThat(cStyleArrays.getParams(), hasEntry("args", "String[]"));
+      assertThat(cStyleArrays.getSignature(), equalTo("class/Foo/method/cStyleArrays(String[])"));
 
-      final FMethod cStyleMultiArrays = new FMethod();
+      final FMethod cStyleMultiArrays = new FMethod().setClazz(clazz);
       cStyleMultiArrays.setDeclaration("String cStyleMultiArrays(String args[][])[][]");
       assertThat(cStyleMultiArrays.getReturnType(), equalTo("String[][]"));
       assertThat(cStyleMultiArrays.getParams(), aMapWithSize(1));
       assertThat(cStyleMultiArrays.getParams(), hasEntry("args", "String[][]"));
+      assertThat(cStyleMultiArrays.getSignature(), equalTo("class/Foo/method/cStyleMultiArrays(String[][])"));
 
-      final FMethod cStyleMixedArrays = new FMethod();
+      final FMethod cStyleMixedArrays = new FMethod().setClazz(clazz);
       cStyleMixedArrays.setDeclaration("String[] cStyleMixedArrays(String[] args[])[]");
       assertThat(cStyleMixedArrays.getReturnType(), equalTo("String[][]"));
       assertThat(cStyleMixedArrays.getParams(), aMapWithSize(1));
       assertThat(cStyleMixedArrays.getParams(), hasEntry("args", "String[][]"));
+      assertThat(cStyleMixedArrays.getSignature(), equalTo("class/Foo/method/cStyleMixedArrays(String[][])"));
    }
 }

--- a/test/src/main/java/de/uniks/studyright/classModel.yaml
+++ b/test/src/main/java/de/uniks/studyright/classModel.yaml
@@ -45,6 +45,7 @@
   name: 	name
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - university_students: 	AssocRole
   aggregation: 	false
@@ -77,6 +78,7 @@
   name: 	name
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - student_studentId: 	Attribute
   clazz: 	student
@@ -85,6 +87,7 @@
   name: 	studentId
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - student_credits: 	Attribute
   clazz: 	student
@@ -93,6 +96,7 @@
   name: 	credits
   propertyStyle: 	Bean
   type: 	int
+  typeSignature: 	int
 
 - student_motivation: 	Attribute
   clazz: 	student
@@ -101,6 +105,7 @@
   name: 	motivation
   propertyStyle: 	Bean
   type: 	double
+  typeSignature: 	double
 
 - student_uni: 	AssocRole
   aggregation: 	false
@@ -133,6 +138,7 @@
   name: 	roomNo
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - room_topic: 	Attribute
   clazz: 	room
@@ -141,6 +147,7 @@
   name: 	topic
   propertyStyle: 	Bean
   type: 	String
+  typeSignature: 	String
 
 - room_credits: 	Attribute
   clazz: 	room
@@ -149,6 +156,7 @@
   name: 	credits
   propertyStyle: 	Bean
   type: 	int
+  typeSignature: 	int
 
 - room_uni: 	AssocRole
   aggregation: 	false


### PR DESCRIPTION
When setting the type of an attribute, the signature for that type is now automatically computed and stored in the typeSignature property.

The FMethod.getSignature method now utilizes the signature building mechanics of FragmentMapBuilder.

## Bugfixes

* Fixed an issue where attributes with generic or annotated types could cause the generation of duplicate members. #43
* Fixed an issue where methods with parameters of generic or annotated types could be duplicated. #43

Closes #43