### PR TITLE
Fix and improve declaration merging

### DIFF
--- a/src/main/antlr/FulibClass.g4
+++ b/src/main/antlr/FulibClass.g4
@@ -38,7 +38,7 @@ constructorMember: typeParamList? IDENTIFIER
 enumConstants: enumConstant (COMMA enumConstant)*;
 enumConstant: annotation* IDENTIFIER balancedParens? balancedBraces?;
 
-// field: (modifier | annotation)* fieldMember;
+field: (modifier | annotation)* fieldMember;
 fieldMember: type fieldNamePart (COMMA fieldNamePart)* SEMI;
 fieldNamePart: IDENTIFIER arraySuffix* (EQ expr)?;
 

--- a/src/main/antlr/FulibClass.g4
+++ b/src/main/antlr/FulibClass.g4
@@ -17,8 +17,8 @@ importDecl: IMPORT STATIC? qualifiedName (DOT STAR)? SEMI;
 classDecl: (modifier | annotation)* classMember;
 classMember: (CLASS | ENUM | AT? INTERFACE) IDENTIFIER
            typeParamList?
-           (EXTENDS annotatedTypeList)?
-           (IMPLEMENTS annotatedTypeList)?
+           (EXTENDS extendsTypes=annotatedTypeList)?
+           (IMPLEMENTS implementsTypes=annotatedTypeList)?
            classBody;
 
 classBody: LBRACE (enumConstants (SEMI (member | SEMI)*)? | (member | SEMI)*) RBRACE;

--- a/src/main/java/org/fulib/classmodel/FileFragmentMap.java
+++ b/src/main/java/org/fulib/classmodel/FileFragmentMap.java
@@ -49,6 +49,7 @@ public class FileFragmentMap
 
    private static final Pattern CLASS_DECL_PATTERN = Pattern.compile("^" + CLASS + "/(\\w+)/" + CLASS_DECL + "$");
    private static final Pattern CLASS_END_PATTERN = Pattern.compile("^" + CLASS + "/(\\w+)/" + CLASS_END + "$");
+   private static final Pattern ATTRIBUTE_PATTERN = Pattern.compile("^" + CLASS + "/(\\w+)/" + ATTRIBUTE + "/(\\w+)$");
 
    private static final String GAP_BEFORE = "#gap-before";
 
@@ -578,11 +579,11 @@ public class FileFragmentMap
          // newtext contains annotations, thus it overrides annotations in the code
          // do not modify newtext
       }
-      else if (key.equals(CLASS))
+      else if (CLASS_DECL_PATTERN.matcher(key).matches())
       {
          newText = mergeClassDecl(oldText, newText);
       }
-      else if (key.startsWith(ATTRIBUTE))
+      else if (ATTRIBUTE_PATTERN.matcher(key).matches())
       {
          newText = mergeAttributeDecl(oldText, newText);
       }

--- a/src/test/java/org/fulib/classmodel/FileFragmentMapTest.java
+++ b/src/test/java/org/fulib/classmodel/FileFragmentMapTest.java
@@ -48,6 +48,34 @@ class FileFragmentMapTest
    }
 
    @Test
+   void mergeAttributeDecl()
+   {
+      assertThat("it ignores multi-declarations", FileFragmentMap.mergeAttributeDecl("int x, y;", "long x;"),
+                 equalTo("int x, y;"));
+
+      assertThat("it removes the initializer", FileFragmentMap.mergeAttributeDecl("int x = 0;", "int x;"),
+                 equalTo("int x;"));
+      assertThat("it removes the initializer and keeps annotations",
+                 FileFragmentMap.mergeAttributeDecl("@Cool int x = 0;", "int x;"), equalTo("@Cool int x;"));
+
+      assertThat("it replaces the initializer", FileFragmentMap.mergeAttributeDecl("int x = 0;", "int x = 1;"),
+                 equalTo("int x = 1;"));
+      assertThat("it replaces the initializer and keeps annotations",
+                 FileFragmentMap.mergeAttributeDecl("@Cool int x = 0;", "int x = 1;"), equalTo("@Cool int x = 1;"));
+
+      assertThat("it adds the initializer", FileFragmentMap.mergeAttributeDecl("int x;", "int x = 1;"),
+                 equalTo("int x = 1;"));
+      assertThat("it adds the initializer and keeps annotations",
+                 FileFragmentMap.mergeAttributeDecl("@Cool int x;", "int x = 1;"), equalTo("@Cool int x = 1;"));
+
+      assertThat("it updates the type", FileFragmentMap.mergeAttributeDecl("int x;", "long x;"), equalTo("long x;"));
+      assertThat("it updates the type and keeps annotations",
+                 FileFragmentMap.mergeAttributeDecl("@Cool int x;", "long x;"), equalTo("@Cool long x;"));
+      assertThat("it updates the type and removes C-style arrays",
+                 FileFragmentMap.mergeAttributeDecl("int x[];", "long x;"), equalTo("long x;"));
+   }
+
+   @Test
    void getPath()
    {
       // assertThat(FileFragmentMap.getPath(""), emptyArray());

--- a/src/test/java/org/fulib/classmodel/FileFragmentMapTest.java
+++ b/src/test/java/org/fulib/classmodel/FileFragmentMapTest.java
@@ -11,20 +11,40 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FileFragmentMapTest
 {
    @Test
    void mergeClassDecl()
    {
-      assertEquals("@Cool class Foo\n{", FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo {"));
-      assertEquals("@Cool class Foo extends Bar\n{",
-                   FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo extends Bar {"));
-      assertEquals("class Foo implements Serializable {",
-                   FileFragmentMap.mergeClassDecl("class Foo implements Serializable {", "class Foo {"));
-      assertEquals("class Foo extends Bar implements Baz {",
-                   FileFragmentMap.mergeClassDecl("class Foo implements Baz {", "class Foo extends Bar {"));
+      assertThat("it keeps annotations", FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo {"),
+                 equalTo("@Cool class Foo {"));
+      assertThat("it keeps interfaces",
+                 FileFragmentMap.mergeClassDecl("class Foo implements Serializable {", "class Foo {"),
+                 equalTo("class Foo implements Serializable {"));
+
+      assertThat("it removes extends clause", FileFragmentMap.mergeClassDecl("class Foo extends Bar {", "class Foo {"),
+                 equalTo("class Foo {"));
+      assertThat("it removes extends clause and keeps interfaces",
+                 FileFragmentMap.mergeClassDecl("class Foo extends Bar implements Baz {", "class Foo {"),
+                 equalTo("class Foo implements Baz {"));
+
+      assertThat("it adds extends clause before interface",
+                 FileFragmentMap.mergeClassDecl("class Foo implements Baz {", "class Foo extends Bar {"),
+                 equalTo("class Foo extends Bar implements Baz {"));
+      assertThat("it adds extends clause before body",
+                 FileFragmentMap.mergeClassDecl("class Foo {", "class Foo extends Bar {"),
+                 equalTo("class Foo extends Bar {"));
+      assertThat("it adds extends clause and keeps annotations",
+                 FileFragmentMap.mergeClassDecl("@Cool class Foo {", "class Foo extends Bar {"),
+                 equalTo("@Cool class Foo extends Bar {"));
+
+      assertThat("it replaces the super type",
+                 FileFragmentMap.mergeClassDecl("class Foo extends Moo {", "class Foo extends Bar {"),
+                 equalTo("class Foo extends Bar {"));
+      assertThat("it replaces the super type and keeps interfaces",
+                 FileFragmentMap.mergeClassDecl("class Foo extends Moo implements Baz {", "class Foo extends Bar {"),
+                 equalTo("class Foo extends Bar implements Baz {"));
    }
 
    @Test


### PR DESCRIPTION
## Bugfixes

* Fixed an issue that would always override class and attribute declarations instead of intelligently merging the original source and newly generated code.

## Improvements

* Improved the way class and attribute declarations are merged from original source and newly generated code.
  * Class declarations are now mostly kept intact, only the type in the extends clause is updated.
  * Attribute declarations are now mostly kept intact, only the type and initializer are updated.