### PR TITLE
Improve import(...) syntax

### DIFF
--- a/src/main/antlr/FulibClass.g4
+++ b/src/main/antlr/FulibClass.g4
@@ -59,7 +59,7 @@ typeParamList: LANGLE (typeParam (COMMA typeParam)*)? RANGLE;
 typeParam: annotation* IDENTIFIER (EXTENDS annotatedType (AMP annotatedType)*)?;
 typeArg: annotation* (QMARK (EXTENDS annotatedType | SUPER annotatedType)? | type);
 
-type: (primitiveType | referenceType) arraySuffix*;
+type: (primitiveType | referenceType | importType) arraySuffix*;
 arraySuffix: annotation* LBRACKET RBRACKET;
 annotatedType: annotation* type;
 annotatedTypeList: annotatedType (COMMA annotatedType)*;
@@ -67,12 +67,14 @@ annotatedTypeList: annotatedType (COMMA annotatedType)*;
 primitiveType: VOID | BOOLEAN | BYTE | SHORT | CHAR | INT | LONG | FLOAT | DOUBLE;
 referenceType: referenceTypePart (DOT annotation* referenceTypePart)*;
 referenceTypePart: IDENTIFIER typeArgList?;
+importTypeName: IMPORT LPAREN qualifiedName RPAREN;
+importType: importTypeName typeArgList?;
 typeArgList: LANGLE (typeArg (COMMA typeArg)*)? RANGLE;
 
 // --------------- Misc. ---------------
 
 modifier: PUBLIC | PROTECTED | PRIVATE | ABSTRACT | STATIC | FINAL | TRANSIENT | VOLATILE | SYNCHRONIZED | NATIVE | STRICTFP | DEFAULT;
-annotation: AT qualifiedName balancedParens?;
+annotation: AT (qualifiedName | importTypeName) balancedParens?;
 
 expr: (balancedBraces
       | balancedParens

--- a/src/main/java/org/fulib/parser/FragmentMapBuilder.java
+++ b/src/main/java/org/fulib/parser/FragmentMapBuilder.java
@@ -297,6 +297,10 @@ public class FragmentMapBuilder extends FulibClassBaseListener
       {
          writeType(typeCtx.primitiveType(), builder);
       }
+      else if (typeCtx.importType() != null)
+      {
+         writeType(typeCtx.importType(), builder);
+      }
       else
       {
          writeType(typeCtx.referenceType(), builder);
@@ -327,11 +331,22 @@ public class FragmentMapBuilder extends FulibClassBaseListener
       }
    }
 
+   private static void writeType(ImportTypeContext importTypeCtx, StringBuilder builder)
+   {
+      // import(org.example.Foo) ends up as only Foo in the code, so the signature should also use the simple name
+      final List<TerminalNode> identifiers = importTypeCtx.importTypeName().qualifiedName().IDENTIFIER();
+      builder.append(identifiers.get(identifiers.size() - 1).getText());
+      writeTypeArgs(importTypeCtx.typeArgList(), builder);
+   }
+
    private static void writeType(ReferenceTypePartContext referenceTypePartCtx, StringBuilder builder)
    {
       builder.append(referenceTypePartCtx.IDENTIFIER().getText());
+      writeTypeArgs(referenceTypePartCtx.typeArgList(), builder);
+   }
 
-      final TypeArgListContext typeArgListCtx = referenceTypePartCtx.typeArgList();
+   private static void writeTypeArgs(TypeArgListContext typeArgListCtx, StringBuilder builder)
+   {
       if (typeArgListCtx == null)
       {
          return;

--- a/src/main/java/org/fulib/util/AbstractGenerator4ClassFile.java
+++ b/src/main/java/org/fulib/util/AbstractGenerator4ClassFile.java
@@ -31,7 +31,7 @@ public abstract class AbstractGenerator4ClassFile
    // =============== Constants ===============
 
    private static final Pattern SIGNATURE_PATTERN = Pattern.compile("^\\s*(\\w+)\\s*:\\s*(.*)\\s*$");
-   private static final Pattern IMPORT_PATTERN = Pattern.compile("import\\(((?:\\w+\\.)*(\\w+))\\)");
+   private static final Pattern IMPORT_PATTERN = Pattern.compile("import\\(((?:static\\s+)?(?:\\w+\\.)*(\\w+))\\)");
 
    // =============== Fields ===============
 

--- a/src/main/java/org/fulib/util/Generator4ClassFile.java
+++ b/src/main/java/org/fulib/util/Generator4ClassFile.java
@@ -240,19 +240,10 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
          body = body.substring(0, body.length() - 1);
       }
 
-      final String signature = method.getSignature();
-      if (method.getModified())
-      {
-         fragmentMap.remove(signature);
-      }
-      else
-      {
-         final STGroup group = this.getSTGroup("org/fulib/templates/method.stg");
-         final ST method1 = group.getInstanceOf("method");
-         method1.add("method", method);
-         method1.add("body", body);
-         fragmentMap.add(signature, method1.render(), METHOD_NEWLINES);
-      }
+      final STGroup group = this.getSTGroup("org/fulib/templates/method.stg");
+      final String finalBody = body;
+      this.generateFromSignatures(fragmentMap, group, "methodSignatures", method.getModified(),
+                                  st -> st.add("method", method).add("body", finalBody));
    }
 
    // --------------- Additional Fragments ---------------

--- a/src/main/resources/org/fulib/templates/method.stg
+++ b/src/main/resources/org/fulib/templates/method.stg
@@ -1,3 +1,7 @@
+methodSignatures(method, body) ::= <<
+method: <method.signature>
+>>
+
 method(method, body) ::= <<
    <if(method.annotations)><method.annotations>
    <endif>

--- a/src/test/java/org/fulib/generator/FMethodTest.java
+++ b/src/test/java/org/fulib/generator/FMethodTest.java
@@ -68,12 +68,8 @@ public class FMethodTest
       returnCode = Tools.javac(outFolder, model.getPackageSrcFolder());
       assertThat("compiler return code: ", returnCode, is(0));
 
-      party.withImports("import org.junit.jupiter.api.Test;");
-      party.withImports("import static org.hamcrest.CoreMatchers.*;");
-      party.withImports("import static org.hamcrest.MatcherAssert.assertThat;");
-
-      mm.haveMethod(party, "" + "@Test\n" + "public void testQuestion()",
-                    "" + "      assertThat(theAnswer(21), equalTo(42));\n");
+      mm.haveMethod(party, "@import(org.junit.jupiter.api.Test) public void testQuestion()",
+                    "import(static org.hamcrest.MatcherAssert.assertThat)(theAnswer(21), import(static org.hamcrest.CoreMatchers.equalTo)(42));");
 
       Fulib.generator().generate(model);
 


### PR DESCRIPTION
## Improvements

* `FMethods` now support `import(...)` syntax.
* The parser now supports `import(...)` syntax in type uses and annotations.
* `import(...)` syntax now supports `static` imports via `import(static ...)`.