### PR TITLE
Fix removal of PropertyChange members

### DIFF
--- a/src/main/java/org/fulib/util/Generator4ClassFile.java
+++ b/src/main/java/org/fulib/util/Generator4ClassFile.java
@@ -250,14 +250,11 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
 
    private void generatePropertyChangeSupport(Clazz clazz, FileFragmentMap fragmentMap)
    {
-      if (clazz.getAttributes().isEmpty() && clazz.getRoles().isEmpty())
-      {
-         return;
-      }
-
       final STGroup group = this.getSTGroup("org/fulib/templates/propertyChangeSupport.stg");
-      this.generateFromSignatures(fragmentMap, group, "propertyChangeSignatures", clazz.getModified(),
-                                  st -> st.add("clazz", clazz));
+      final boolean hasSuperClass = clazz.getSuperClass() != null;
+      final boolean hasNoDataMembers = clazz.getAttributes().isEmpty() && clazz.getRoles().isEmpty();
+      final boolean remove = clazz.getModified() || hasSuperClass || hasNoDataMembers;
+      this.generateFromSignatures(fragmentMap, group, "propertyChangeSignatures", remove, st -> st.add("clazz", clazz));
    }
 
    private void generateToString(Clazz clazz, FileFragmentMap fragmentMap)

--- a/src/main/java/org/fulib/util/Generator4ClassFile.java
+++ b/src/main/java/org/fulib/util/Generator4ClassFile.java
@@ -257,7 +257,7 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
 
    private static boolean needsPropertyChangeSupport(Clazz clazz)
    {
-      if (!hasDataMembers(clazz))
+      if (!needsPropertyChangeSupportIgnoringSuper(clazz))
       {
          // no data members means no PropertyChange is needed at all, regardless of superclasses
          return false;
@@ -265,7 +265,7 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
       Clazz superClazz = clazz;
       while ((superClazz = superClazz.getSuperClass()) != null)
       {
-         if (hasDataMembers(superClazz))
+         if (needsPropertyChangeSupportIgnoringSuper(superClazz))
          {
             // one of the super classes already contains PropertyChange members, no need to duplicate them
             return false;
@@ -273,6 +273,11 @@ public class Generator4ClassFile extends AbstractGenerator4ClassFile
       }
       // no super class or none with PropertyChange members, we need to generate them ourselves
       return true;
+   }
+
+   private static boolean needsPropertyChangeSupportIgnoringSuper(Clazz clazz)
+   {
+      return hasDataMembers(clazz) && !Type.POJO.equals(clazz.getPropertyStyle());
    }
 
    private static boolean hasDataMembers(Clazz superClazz)


### PR DESCRIPTION
## Bugfixes

* The code generator now properly removes PropertyChange members when they are not needed.
* The code generator now correctly determines when PropertyChange members are needed, depending on attributes, associations, potential super classes and the use of `POJO` property style.