### PR TITLE
Check for syntax errors in FMethod.setDeclaration

### DIFF
--- a/src/main/java/org/fulib/classmodel/FMethod.java
+++ b/src/main/java/org/fulib/classmodel/FMethod.java
@@ -5,6 +5,7 @@ import org.antlr.v4.runtime.misc.Interval;
 import org.fulib.parser.FragmentMapBuilder;
 import org.fulib.parser.FulibClassLexer;
 import org.fulib.parser.FulibClassParser;
+import org.fulib.parser.FulibErrorHandler;
 import org.fulib.util.Validator;
 
 import java.beans.PropertyChangeListener;
@@ -151,7 +152,17 @@ public class FMethod
       final FulibClassLexer lexer = new FulibClassLexer(input);
       final FulibClassParser parser = new FulibClassParser(new CommonTokenStream(lexer));
 
+      final StringBuilder errors = new StringBuilder("syntax errors in declaration:\n").append(value).append('\n');
+      parser.removeErrorListeners();
+      parser.addErrorListener(new FulibErrorHandler(errors));
+
       final FulibClassParser.MethodContext methodCtx = parser.method();
+
+      if (parser.getNumberOfSyntaxErrors() > 0)
+      {
+         throw new IllegalArgumentException(errors.toString());
+      }
+
       final FulibClassParser.MethodMemberContext memberCtx = methodCtx.methodMember();
 
       final String annotations = methodCtx

--- a/src/main/java/org/fulib/classmodel/FMethod.java
+++ b/src/main/java/org/fulib/classmodel/FMethod.java
@@ -99,8 +99,7 @@ public class FMethod
    }
 
    /**
-    * @return the declaration of this method.
-    * Includes header, including annotations, modifiers, return type, name, and parameters.
+    * @return the declaration of this method, including annotations, modifiers, return type, name, and parameters
     */
    public String getDeclaration() // no fulib
    {
@@ -136,6 +135,15 @@ public class FMethod
       return inputStream.getText(Interval.of(start.getStartIndex(), rule.getStop().getStopIndex()));
    }
 
+   /**
+    * @param value
+    *    the declaration of this method, including annotations, modifiers, return type, name, and parameters
+    *
+    * @return this
+    *
+    * @throws IllegalArgumentException
+    *    if the declaration has syntax errors
+    */
    public FMethod setDeclaration(String value) // no fulib
    {
       // a declaration looks like

--- a/src/main/java/org/fulib/parser/FulibErrorHandler.java
+++ b/src/main/java/org/fulib/parser/FulibErrorHandler.java
@@ -4,13 +4,13 @@ import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 
-import java.io.PrintWriter;
+import java.io.IOException;
 
-class FulibErrorHandler extends BaseErrorListener
+public class FulibErrorHandler extends BaseErrorListener
 {
-   private final PrintWriter out;
+   private final Appendable out;
 
-   FulibErrorHandler(PrintWriter out)
+   public FulibErrorHandler(Appendable out)
    {
       this.out = out;
    }
@@ -25,6 +25,23 @@ class FulibErrorHandler extends BaseErrorListener
 
    private void report(String file, int line, int column, String type, String msg)
    {
-      this.out.println(file + ":" + line + ":" + column + ": " + type + ": " + msg);
+      try
+      {
+         this.out
+            .append(file)
+            .append(':')
+            .append(String.valueOf(line))
+            .append(':')
+            .append(String.valueOf(column))
+            .append(": ")
+            .append(type)
+            .append(": ")
+            .append(msg)
+            .append('\n');
+      }
+      catch (IOException e)
+      {
+         e.printStackTrace();
+      }
    }
 }

--- a/src/test/java/org/fulib/classmodel/FMethodTest.java
+++ b/src/test/java/org/fulib/classmodel/FMethodTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FMethodTest
 {
@@ -90,5 +91,19 @@ class FMethodTest
       assertThat(cStyleMixedArrays.getParams(), aMapWithSize(1));
       assertThat(cStyleMixedArrays.getParams(), hasEntry("args", "String[][]"));
       assertThat(cStyleMixedArrays.getSignature(), equalTo("class/Foo/method/cStyleMixedArrays(String[][])"));
+   }
+
+   @Test
+   void setDeclaration_syntaxErrors()
+   {
+      final FMethod syntaxErrors = new FMethod();
+
+      final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+         syntaxErrors.setDeclaration("void (x, y)");
+      });
+
+      assertThat(ex.getMessage(), equalTo("syntax errors in declaration:\n" + "void (x, y)\n"
+                                          + "<unknown>:1:5: syntax: extraneous input '(' expecting IDENTIFIER\n"
+                                          + "<unknown>:1:7: syntax: mismatched input ',' expecting {'@', '[', IDENTIFIER}\n"));
    }
 }


### PR DESCRIPTION
## Improvements

* The `FMethod.setDeclaration` method now throws an `IllegalArgumentException` if the new value has syntax errors.