### PR TITLE
Add FMethod.getId

### DIFF
--- a/src/main/java/org/fulib/classmodel/AssocRole.java
+++ b/src/main/java/org/fulib/classmodel/AssocRole.java
@@ -126,7 +126,9 @@ public class AssocRole
     * @return a string that uniquely identifies this role within the enclosing class model
     *
     * @since 1.2
+    * @deprecated since 1.3; for serialization purposes only
     */
+   @Deprecated
    public String getId()
    {
       final String className = this.getClazz() == null ? "___" : this.getClazz().getName();

--- a/src/main/java/org/fulib/classmodel/AssocRole.java
+++ b/src/main/java/org/fulib/classmodel/AssocRole.java
@@ -131,8 +131,8 @@ public class AssocRole
    @Deprecated
    public String getId()
    {
-      final String className = this.getClazz() == null ? "___" : this.getClazz().getName();
-      return className + "_" + this.getName();
+      final Clazz clazz = this.getClazz();
+      return (clazz != null ? clazz.getName() : "_") + "_" + this.getName();
    }
 
    public String getName()

--- a/src/main/java/org/fulib/classmodel/Attribute.java
+++ b/src/main/java/org/fulib/classmodel/Attribute.java
@@ -106,8 +106,8 @@ public class Attribute
    @Deprecated
    public String getId()
    {
-      final String className = this.getClazz() != null ? this.getClazz().getName() : "___";
-      return className + "_" + this.getName();
+      final Clazz clazz = this.getClazz();
+      return (clazz != null ? clazz.getName() : "_") + "_" + this.getName();
    }
 
    public String getName()

--- a/src/main/java/org/fulib/classmodel/Attribute.java
+++ b/src/main/java/org/fulib/classmodel/Attribute.java
@@ -101,7 +101,9 @@ public class Attribute
     * @return a string that uniquely identifies this attribute within the enclosing class model
     *
     * @since 1.2
+    * @deprecated since 1.3; for serialization purposes only
     */
+   @Deprecated
    public String getId()
    {
       final String className = this.getClazz() != null ? this.getClazz().getName() : "___";

--- a/src/main/java/org/fulib/classmodel/FMethod.java
+++ b/src/main/java/org/fulib/classmodel/FMethod.java
@@ -81,6 +81,19 @@ public class FMethod
    }
 
    /**
+    * @return a string that identifies this method within the enclosing class model
+    *
+    * @since 1.3
+    * @deprecated for serialization purposes only
+    */
+   @Deprecated
+   public String getId()
+   {
+      final Clazz clazz = this.getClazz();
+      return (clazz != null ? clazz.getName() : "_") + "_" + this.getName();
+   }
+
+   /**
     * @since 1.2
     */
    public String getName()


### PR DESCRIPTION
The new `FMethod.getId` method slightly improves serialization behaviour. The old `Attribute.getId` and `AssocRole.getId` methods were deprecated and slightly changed to produce less underscores.