### PR TITLE
Properly replace fully qualified class names

### DIFF
--- a/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
+++ b/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
@@ -118,6 +118,21 @@ class ReflectiveClassBuilder
 
    private static void toSource(Class<?> base, String className, StringBuilder out)
    {
+      switch (className)
+      {
+      case "void":
+      case "boolean":
+      case "byte":
+      case "short":
+      case "char":
+      case "int":
+      case "long":
+      case "float":
+      case "double":
+         out.append(className);
+         return;
+      }
+
       try
       {
          final Class<?> resolved = Class.forName(className);

--- a/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
+++ b/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
@@ -16,7 +16,7 @@ import static org.fulib.builder.Type.ONE;
 class ReflectiveClassBuilder
 {
    private static final String ID_PATTERN = "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";
-   private static final Pattern CLASS_PATTERN = Pattern.compile("class (" + ID_PATTERN + "(?:\\." + ID_PATTERN + ")*)");
+   private static final Pattern CLASS_PATTERN = Pattern.compile(ID_PATTERN + "(?:\\." + ID_PATTERN + ")*");
 
    static Clazz load(Class<?> classDef, ClassModelManager manager)
    {
@@ -101,13 +101,13 @@ class ReflectiveClassBuilder
 
    private static String toSource(Class<?> base, Type type)
    {
-      final String input = type.toString();
+      final String input = type.getTypeName();
       final Matcher matcher = CLASS_PATTERN.matcher(input);
       final StringBuilder sb = new StringBuilder();
       int prev = 0;
       while (matcher.find())
       {
-         final String className = matcher.group(1);
+         final String className = matcher.group();
          sb.append(input, prev, matcher.start());
          toSource(base, className, sb);
          prev = matcher.end();
@@ -116,7 +116,8 @@ class ReflectiveClassBuilder
       return sb.toString();
    }
 
-   private static void toSource(Class<?> base, String className, StringBuilder out) {
+   private static void toSource(Class<?> base, String className, StringBuilder out)
+   {
       try
       {
          final Class<?> resolved = Class.forName(className);

--- a/src/test/java/org/fulib/builder/ReflectiveClassBuilderTest.java
+++ b/src/test/java/org/fulib/builder/ReflectiveClassBuilderTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Predicate;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,6 +47,8 @@ public class ReflectiveClassBuilderTest
 
       @Link("manager")
       List<Employee> subordinates;
+
+      Predicate<?> predicate;
    }
 
    class University
@@ -102,6 +105,9 @@ public class ReflectiveClassBuilderTest
       assertThat(notesCollectionType.getItf(), is(CollectionInterface.List));
 
       final Clazz employee = model.getClazz("Employee");
+
+      final Attribute predicate = employee.getAttribute("predicate");
+      assertThat(predicate.getType(), equalTo("import(java.util.function.Predicate)<?>"));
 
       final AssocRole manager = employee.getRole("manager");
       final AssocRole subordinates = employee.getRole("subordinates");


### PR DESCRIPTION
## Bugfixes

* The reflective class model builder now properly replaces fully qualified class names with imports.