### PR TITLE
Cross package attribute types

### DIFF
--- a/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
+++ b/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
@@ -146,6 +146,16 @@ class ReflectiveClassBuilder
          {
             out.append(resolved.getSimpleName());
          }
+         else if (ClassModelDecorator.class.isAssignableFrom(resolved.getEnclosingClass()))
+         {
+            // resolved is nested class within another GenModel
+            out
+               .append("import(")
+               .append(resolvedPackage.getName())
+               .append('.')
+               .append(resolved.getSimpleName())
+               .append(')');
+         }
          else
          {
             out.append("import(").append(canonicalName).append(')');

--- a/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
+++ b/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
@@ -146,7 +146,7 @@ class ReflectiveClassBuilder
          {
             out.append(resolved.getSimpleName());
          }
-         else if (ClassModelDecorator.class.isAssignableFrom(resolved.getEnclosingClass()))
+         else if (resolved.getEnclosingClass() != null && ClassModelDecorator.class.isAssignableFrom(resolved.getEnclosingClass()))
          {
             // resolved is nested class within another GenModel
             out

--- a/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
+++ b/src/main/java/org/fulib/builder/ReflectiveClassBuilder.java
@@ -186,6 +186,7 @@ class ReflectiveClassBuilder
 
    private static void loadAssoc(Field field, Link link, Clazz clazz, ClassModelManager manager)
    {
+      final Class<?> owner = field.getDeclaringClass();
       final String name = field.getName();
       final CollectionType collectionType = getCollectionType(field.getType());
 
@@ -196,10 +197,11 @@ class ReflectiveClassBuilder
       }
 
       final Class<?> other = getOther(field, collectionType);
+      validateTargetClass(owner, name, other);
 
       if (otherName != null)
       {
-         validateLinkTarget(field.getDeclaringClass(), name, otherName, other);
+         validateLinkTarget(owner, name, otherName, other);
       }
 
       final String otherClazzName = other.getSimpleName();
@@ -210,6 +212,17 @@ class ReflectiveClassBuilder
       role.setCollectionType(collectionType);
       role.setDescription(getDescription(field));
       role.setSince(getSince(field));
+   }
+
+   private static void validateTargetClass(Class<?> owner, String name, Class<?> other)
+   {
+      if (owner.getPackage() != other.getPackage())
+      {
+         throw new InvalidClassModelException(
+            String.format("%s.%s: invalid link: target class %s (%s) must be in the same package (%s)",
+                          owner.getSimpleName(), name, other.getSimpleName(), other.getPackage().getName(),
+                          owner.getPackage().getName()));
+      }
    }
 
    private static void validateLinkTarget(Class<?> owner, String name, String otherName, Class<?> other)

--- a/src/test/java/org/fulib/builder/ReflectiveClassBuilderTest.java
+++ b/src/test/java/org/fulib/builder/ReflectiveClassBuilderTest.java
@@ -1,5 +1,6 @@
 package org.fulib.builder;
 
+import org.fulib.builder.event.GenEvents;
 import org.fulib.builder.reflect.*;
 import org.fulib.classmodel.*;
 import org.junit.jupiter.api.Test;
@@ -283,5 +284,17 @@ public class ReflectiveClassBuilderTest
 
       assertThat(ex.getMessage(), equalTo(
          "InvalidLinkTargetClass.students: invalid link target: field Student.uni has target type University instead of InvalidLinkTargetClass"));
+   }
+
+   @Test
+   public void crossGenModelReference()
+   {
+      final ClassModelManager cmmEvents = new ClassModelManager();
+      cmmEvents.haveNestedClasses(GenEvents.class);
+
+      final ClassModel classModelEvents = cmmEvents.getClassModel();
+      final Clazz studentEvent = classModelEvents.getClazz("StudentEvent");
+      final Attribute studentEventStudent = studentEvent.getAttribute("student");
+      assertThat(studentEventStudent.getType(), is("import(org.fulib.builder.model.Student)"));
    }
 }

--- a/src/test/java/org/fulib/builder/ReflectiveClassBuilderTest.java
+++ b/src/test/java/org/fulib/builder/ReflectiveClassBuilderTest.java
@@ -1,6 +1,7 @@
 package org.fulib.builder;
 
 import org.fulib.builder.event.GenEvents;
+import org.fulib.builder.model.GenModel;
 import org.fulib.builder.reflect.*;
 import org.fulib.classmodel.*;
 import org.junit.jupiter.api.Test;
@@ -296,5 +297,24 @@ public class ReflectiveClassBuilderTest
       final Clazz studentEvent = classModelEvents.getClazz("StudentEvent");
       final Attribute studentEventStudent = studentEvent.getAttribute("student");
       assertThat(studentEventStudent.getType(), is("import(org.fulib.builder.model.Student)"));
+   }
+
+   class InvalidLinkClassPackage
+   {
+      @Link
+      GenModel.Student student;
+   }
+
+   @Test
+   public void invalidLinkClassPackage()
+   {
+      final ClassModelManager cmm = new ClassModelManager();
+
+      final InvalidClassModelException ex = assertThrows(InvalidClassModelException.class,
+                                                         () -> ReflectiveClassBuilder.load(
+                                                            InvalidLinkClassPackage.class, cmm));
+
+      assertThat(ex.getMessage(), equalTo(
+         "InvalidLinkClassPackage.student: invalid link: target class Student (org.fulib.builder.model) must be in the same package (org.fulib.builder)"));
    }
 }

--- a/src/test/java/org/fulib/builder/event/GenEvents.java
+++ b/src/test/java/org/fulib/builder/event/GenEvents.java
@@ -1,0 +1,13 @@
+package org.fulib.builder.event;
+
+import org.fulib.builder.ClassModelDecorator;
+import org.fulib.builder.model.GenModel;
+
+public class GenEvents implements ClassModelDecorator
+{
+   class StudentEvent
+   {
+      GenModel.Student student;
+   }
+}
+

--- a/src/test/java/org/fulib/builder/model/GenModel.java
+++ b/src/test/java/org/fulib/builder/model/GenModel.java
@@ -1,0 +1,10 @@
+package org.fulib.builder.model;
+
+import org.fulib.builder.ClassModelDecorator;
+
+public class GenModel implements ClassModelDecorator
+{
+   public class Student
+   {}
+}
+


### PR DESCRIPTION
<!-- Please enter your detailed description below. -->

<!-- Please select the relevant change category and write a short changelog entry using the relevant style -->

## Improvements

+ Attributes reflectively loaded in one `ClassModelDecorator` can now use types from a `ClassModelDecorator` in a different package.

## Bugfixes

* Associations declared with `@Link` can no longer reference types in other packages.

Closes #96
