### PR TITLE
fix: Fix links (remove www)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Great care is taken that no hand-written code is deleted or changed by code gene
 Fulib is able to read and modify any Java code using language features from up to Java 11,
 even if it contains syntax errors or can otherwise not be compiled.
 
-We have an Online Version at www.fulib.org where you can find docs and tutorials for getting started.
+We have an Online Version at [fulib.org](https://fulib.org) where you can find docs and tutorials for getting started.
 
 ## Installation
 


### PR DESCRIPTION
<!-- Please enter your detailed description below. -->
Removes www from fulib.org links since it leads to a 404 error page

<!-- Please select the relevant change category and write a short changelog entry using the relevant style -->

## General/New Features/Improvements/Bugfixes/Deprecations/Removals
* Fixed links by removing www

Closes issue #105 
